### PR TITLE
The options should be a subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,17 @@ mod traverse;
 
 #[derive(StructOpt)]
 #[structopt(bin_name("cargo"))]
-struct Opt {
-    #[structopt(long = "crate", default_value = ".")]
-    crate_path: PathBuf,
-    #[structopt(long, default_value = "src/main.rs")]
-    entry_point: PathBuf,
+enum Opt {
+    AutoBundle {
+        #[structopt(long = "crate", default_value = ".")]
+        crate_path: PathBuf,
+        #[structopt(long, default_value = "src/main.rs")]
+        entry_point: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
-    let Opt {
+    let Opt::AutoBundle {
         crate_path,
         entry_point,
     } = Opt::from_args();


### PR DESCRIPTION
```diff
-$ cargo-auto-bundle --help
+$ cargo auto-bundle --help
 cargo-auto-bundle 0.1.0

 USAGE:
-    cargo [OPTIONS]
+    cargo auto-bundle [OPTIONS]

 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information

 OPTIONS:
         --crate <crate-path>            [default: .]
         --entry-point <entry-point>     [default: src/main.rs]
```
